### PR TITLE
Fix Util Types

### DIFF
--- a/src/styles/stitches.config.ts
+++ b/src/styles/stitches.config.ts
@@ -1,5 +1,9 @@
 import { createStitches } from "@stitches/react";
 
+import type * as Stitches from "@stitches/react";
+
+type UtilValue = Stitches.ScaleValue<"space"> | number | string;
+
 export const {
   styled,
   css,
@@ -12,15 +16,22 @@ export const {
 } = createStitches({
   theme: {
     colors: {},
+    space: {},
   },
   media: {
     tablet: "(min-width: 768px)",
     desktop: "(min-width: 1024px)",
   },
   utils: {
-    mx: (value: number | string) => ({ marginLeft: value, marginRight: value }),
-    my: (value: number | string) => ({ marginTop: value, marginBottom: value }),
-    px: (value: number | string) => ({ paddingLeft: value, paddingRight: value }),
-    py: (value: number | string) => ({ paddingTop: value, paddingBottom: value }),
+    mx: (value: UtilValue) => ({ marginLeft: value, marginRight: value }),
+    my: (value: UtilValue) => ({ marginTop: value, marginBottom: value }),
+    px: (value: UtilValue) => ({
+      paddingLeft: value,
+      paddingRight: value,
+    }),
+    py: (value: UtilValue) => ({
+      paddingTop: value,
+      paddingBottom: value,
+    }),
   },
 });


### PR DESCRIPTION
Adds TS types to stitches util functions

Allows us to do stuff like

```ts
import { styled, theme } from "src/styles/stitches.config";

const StyledDiv = styled('div', {
  px: theme.space.xl
})
```