### PR TITLE
Add stitches utilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nextjs-typescript-stitches-template",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "nextjs-typescript-stitches-template",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "dependencies": {
         "@stitches/react": "^1.2.8",
         "next": "^13.1.1",

--- a/src/styles/stitches.config.ts
+++ b/src/styles/stitches.config.ts
@@ -1,9 +1,7 @@
 import { createStitches } from "@stitches/react";
 
 import type * as Stitches from "@stitches/react";
-import { fuildFontSize, fuildSpacingBottom, fuildSpacingTop } from "./utils";
-
-type UtilValue = Stitches.ScaleValue<"space"> | number | string;
+import { fuildFontSize, makeFluidSpacing, UtilValue } from "./utils";
 
 export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme, config } =
   createStitches({
@@ -57,8 +55,13 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
       p: (value: UtilValue) => ({
         padding: value,
       }),
-      fluidSpacingTop: fuildSpacingTop,
-      fluidSpacingBottom: fuildSpacingBottom,
+      fpt: makeFluidSpacing("paddingTop"),
+      fpr: makeFluidSpacing("paddingRight"),
+      fpb: makeFluidSpacing("paddingBottom"),
+      fpl: makeFluidSpacing("paddingLeft"),
+      fpx: makeFluidSpacing(["paddingLeft", "paddingRight"]),
+      fpy: makeFluidSpacing(["paddingTop", "paddingBottom"]),
+      fp: makeFluidSpacing("padding"),
       userSelect: (value: Stitches.PropertyValue<"userSelect">) => ({
         WebkitUserSelect: value,
         userSelect: value,

--- a/src/styles/stitches.config.ts
+++ b/src/styles/stitches.config.ts
@@ -1,6 +1,7 @@
 import { createStitches } from "@stitches/react";
 
 import type * as Stitches from "@stitches/react";
+import { fuildFontSize, fuildSpacingBottom, fuildSpacingTop } from "./utils";
 
 type UtilValue = Stitches.ScaleValue<"space"> | number | string;
 
@@ -8,6 +9,7 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
   createStitches({
     theme: {
       colors: {},
+      fontSizes: {},
       space: {},
     },
     media: {
@@ -15,6 +17,9 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
       desktop: "(min-width: 1024px)",
     },
     utils: {
+      m: (value: UtilValue) => ({
+        margin: value,
+      }),
       mx: (value: UtilValue) => ({ marginLeft: value, marginRight: value }),
       my: (value: UtilValue) => ({ marginTop: value, marginBottom: value }),
       mt: (value: UtilValue) => ({
@@ -49,5 +54,23 @@ export const { styled, css, globalCss, keyframes, getCssText, theme, createTheme
         paddingTop: value,
         paddingBottom: value,
       }),
+      p: (value: UtilValue) => ({
+        padding: value,
+      }),
+      fluidSpacingTop: fuildSpacingTop,
+      fluidSpacingBottom: fuildSpacingBottom,
+      userSelect: (value: Stitches.PropertyValue<"userSelect">) => ({
+        WebkitUserSelect: value,
+        userSelect: value,
+      }),
+      size: (value: Stitches.PropertyValue<"width">) => ({
+        width: value,
+        height: value,
+      }),
+      appearance: (value: Stitches.PropertyValue<"appearance">) => ({
+        WebkitAppearance: value,
+        appearance: value,
+      }),
+      fluidFontSize: fuildFontSize,
     },
   });

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -2,6 +2,8 @@ import type * as Stitches from "@stitches/react";
 
 import { theme } from "src/styles/stitches.config";
 
+export type UtilValue = Stitches.ScaleValue<"space"> | number | string;
+
 export const convertToRem = (fontSize?: string) => {
   if (!fontSize) return 0;
   return parseInt(fontSize.replace("px", ""), 10) / 16;
@@ -27,9 +29,9 @@ export const fluidify = (minFsRaw: string, maxFsRaw: string) => {
   };
 };
 
-export const fuildSpacing = (
-  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
-) => {
+type FluidSpaceValue = [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">];
+
+export const fuildSpacing = (value: FluidSpaceValue) => {
   // Parse values
   // We check if they are theme tokens and if so get their values
   const minFsRaw =
@@ -49,25 +51,17 @@ export const fuildSpacing = (
   };
 };
 
-export const fuildSpacingTop = (
-  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
-) => {
-  const { clamp } = fuildSpacing(value);
+export function makeFluidSpacing(property: string | string[]) {
+  return function fluidSpace(value: FluidSpaceValue): Record<string, UtilValue> {
+    const { clamp } = fuildSpacing(value);
 
-  return {
-    paddingTop: clamp,
+    if (Array.isArray(property)) {
+      return Object.fromEntries(property.map(prop => [prop, clamp]));
+    }
+
+    return { [property]: clamp };
   };
-};
-
-export const fuildSpacingBottom = (
-  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
-) => {
-  const { clamp } = fuildSpacing(value);
-
-  return {
-    paddingBottom: clamp,
-  };
-};
+}
 
 export const fuildFontSize = (
   value: [Stitches.PropertyValue<"fontSize">, Stitches.PropertyValue<"fontSize">],

--- a/src/styles/utils.ts
+++ b/src/styles/utils.ts
@@ -1,0 +1,92 @@
+import type * as Stitches from "@stitches/react";
+
+import { theme } from "src/styles/stitches.config";
+
+export const convertToRem = (fontSize?: string) => {
+  if (!fontSize) return 0;
+  return parseInt(fontSize.replace("px", ""), 10) / 16;
+};
+
+export const fluidify = (minFsRaw: string, maxFsRaw: string) => {
+  const minVw = convertToRem("320px");
+  const maxVw = convertToRem("1920px");
+
+  const minFs = convertToRem(minFsRaw);
+  const maxFs = convertToRem(maxFsRaw);
+  const factor = (1 / (maxVw - minVw)) * (maxFs - minFs);
+  const calcRem = minFs - minVw * factor;
+  const calcVw = 100 * factor;
+  const calc = `${calcRem}rem + ${calcVw}vw`;
+  const min = Math.min(minFs, maxFs);
+  const max = Math.max(minFs, maxFs);
+
+  return {
+    calc,
+    min,
+    max,
+  };
+};
+
+export const fuildSpacing = (
+  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
+) => {
+  // Parse values
+  // We check if they are theme tokens and if so get their values
+  const minFsRaw =
+    String(value[0]).indexOf("$") === 0
+      ? (theme.space as any)[String(value[0]).replace("$", "")].value
+      : String(value[0]);
+  const maxFsRaw =
+    String(value[1]).indexOf("$") === 0
+      ? (theme.space as any)[String(value[1]).replace("$", "")].value
+      : String(value[1]);
+
+  const { calc, min, max } = fluidify(minFsRaw, maxFsRaw);
+  const clamp = `clamp(${min}rem, ${calc}, ${max}rem);`;
+
+  return {
+    clamp,
+  };
+};
+
+export const fuildSpacingTop = (
+  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
+) => {
+  const { clamp } = fuildSpacing(value);
+
+  return {
+    paddingTop: clamp,
+  };
+};
+
+export const fuildSpacingBottom = (
+  value: [Stitches.PropertyValue<"padding">, Stitches.PropertyValue<"padding">],
+) => {
+  const { clamp } = fuildSpacing(value);
+
+  return {
+    paddingBottom: clamp,
+  };
+};
+
+export const fuildFontSize = (
+  value: [Stitches.PropertyValue<"fontSize">, Stitches.PropertyValue<"fontSize">],
+) => {
+  // Parse values
+  // We check if they are theme tokens and if so get their values
+  const minFsRaw =
+    String(value[0]).indexOf("$") === 0
+      ? (theme.fontSizes as any)[String(value[0]).replace("$", "")].value
+      : String(value[0]);
+  const maxFsRaw =
+    String(value[1]).indexOf("$") === 0
+      ? (theme.fontSizes as any)[String(value[1]).replace("$", "")].value
+      : String(value[1]);
+
+  const { calc, min, max } = fluidify(minFsRaw, maxFsRaw);
+  const clamp = `${min}rem; font-size: clamp(${min}rem, ${calc}, ${max}rem);`;
+
+  return {
+    fontSize: clamp,
+  };
+};


### PR DESCRIPTION
Includes often used stitches utilities:
- `m` and `p` short hand properties
- `size` shorthand for `width` and `height` #15 
- Fluid typography using `fluidFontSize`
- Fluid padding using `f` prefix on all padding properties.
- `appearance` for cross browser reset of form control styles
- `userSelect` for cross browser user selection styles